### PR TITLE
Historic currency data

### DIFF
--- a/src/coin-value-refresh.ts
+++ b/src/coin-value-refresh.ts
@@ -123,21 +123,21 @@ export const coinValueRefresh: ScheduledHandler = async (): Promise<any> => {
   }
 
   const addHistoricDataOperation = async () =>
-  db.query(
-    `
+    db.query(
+      `
     INSERT INTO token_historic_prices (symbol, value) 
     SELECT * FROM UNNEST ($1::TEXT[], $2::DOUBLE PRECISION[]);
     `,
-    [symbols, prices]
-  );
+      [symbols, prices]
+    );
 
-const goAddHistoricDataResponse = await go(addHistoricDataOperation, goQueryConfig);
-if (!goAddHistoricDataResponse.success) {
-  const e = goAddHistoricDataResponse.error as Error;
-  console.error(goAddHistoricDataResponse.error);
-  console.error(e.stack);
-  return;
-}
+  const goAddHistoricDataResponse = await go(addHistoricDataOperation, goQueryConfig);
+  if (!goAddHistoricDataResponse.success) {
+    const e = goAddHistoricDataResponse.error as Error;
+    console.error(goAddHistoricDataResponse.error);
+    console.error(e.stack);
+    return;
+  }
 
   console.log('Values updated successfully');
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
-import { GoAsyncOptions } from "@api3/promise-utils";
+import { GoAsyncOptions } from '@api3/promise-utils';
 
-export const goQueryConfig: GoAsyncOptions = { 
-    attemptTimeoutMs: 5_000, 
-    retries: 2, 
-    totalTimeoutMs: 15_000 
-}
+export const goQueryConfig: GoAsyncOptions = {
+  attemptTimeoutMs: 5_000,
+  retries: 2,
+  totalTimeoutMs: 15_000,
+};


### PR DESCRIPTION
Added `token_historic_prices` table with `created_at`, `symbol` & `value` columns.

Each 10 minutes the `coin-value-refresh` function inserts the current value for each supported token in the table creating this way an historical track of the token prices.

### Example usage
Historic prices of the `bnb` token in the last hour
```sql
SELECT * FROM token_historic_prices 
WHERE symbol = 'bnb' AND created_at > NOW() - INTERVAL '1 hour'
```