### PR TITLE
Constrain on-chain-value query and last-transactions query to beacon value update events

### DIFF
--- a/src/dapi-names.ts
+++ b/src/dapi-names.ts
@@ -12,13 +12,13 @@ export const getDataFeedIdFromDapiName = async (dapiName: string, chainId: strin
     SELECT event_data->'parsedLog'->'args'->> 1 as "dataFeedId"
     FROM dapi_events 
     WHERE 
-    chainId = $1 AND
+    chain = $1 AND
     event_name = 'SetDapiName' AND 
-    event_data->'parsedLog'->'args'->> 0 = $1 
+    event_data->'parsedLog'->'args'->> 0 = $2 
     ORDER BY block DESC
     LIMIT 1;
   `,
-      [chainId, hashedDapiNameId]
+      [parseInt(chainId), hashedDapiNameId]
     );
 
   const goResponse = await go(operation, goQueryConfig);

--- a/src/last-transactions.ts
+++ b/src/last-transactions.ts
@@ -84,6 +84,7 @@ export const lastTransactions: APIGatewayProxyHandler = async (event): Promise<A
     event_data -> 'transactionHash' as "transactionHash"
     FROM dapi_events 
     WHERE chain = $1 AND 
+    event_name IN ('UpdatedBeaconWithSignedData', 'UpdatedBeaconWithPsp', 'UpdatedBeaconWithRrp', 'UpdatedBeaconSetWithBeacons', 'UpdatedBeaconSetWithSignedData') AND
     event_data->'parsedLog'->'args'->> 0 = $2
     ORDER by block DESC LIMIT $3;
   `,

--- a/src/on-chain-value.test.ts
+++ b/src/on-chain-value.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import path from 'path';
 import { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import * as database from './database';
-import { chainValueDataPoint, onChainValueQueryTemplate } from './on-chain-value';
+import { chainValueDataPoint } from './on-chain-value';
 
 describe('handles http queries for on-chain-value for single dataFeedIds', () => {
   it('responds to a valid query', async () => {
@@ -31,10 +31,6 @@ describe('handles http queries for on-chain-value for single dataFeedIds', () =>
     );
     expect(initDb).toHaveBeenCalledTimes(1);
     expect(mockQueryImplementation).toHaveBeenCalledTimes(1);
-    expect(mockQueryImplementation).toHaveBeenCalledWith(onChainValueQueryTemplate, [
-      queryStringParameters.chainId,
-      queryStringParameters.dataFeedId,
-    ]);
 
     expect(result?.statusCode).toEqual(200);
     expect(result?.body).toEqual(`{"beaconResponse":[{"hex":"0x0d9a1ece3a7ef800","type":"BigNumber"},926163856]}`);


### PR DESCRIPTION
This PR limits on-chain-value and last-transactions to retrieving events from the database that have updated the beacon value (as opposed to events that update other things, like dapi names).

This PR also includes inlining of one of the query templates, which should have been done in the previous email validator PR.

This is currently live and deployed. Unfortunately testing this is outside of production is currently very hard to do.

These changes are live: https://market.api3.org/beacons