### PR TITLE
Increase lastTransactions query to last 25 hours

### DIFF
--- a/src/last-transactions.ts
+++ b/src/last-transactions.ts
@@ -84,7 +84,7 @@ export const lastTransactions: APIGatewayProxyHandler = async (event): Promise<A
     WHERE chain = $1 AND 
     event_name IN ('UpdatedBeaconWithSignedData', 'UpdatedBeaconWithPsp', 'UpdatedBeaconWithRrp', 'UpdatedBeaconSetWithBeacons', 'UpdatedBeaconSetWithSignedData') AND
     event_data->'parsedLog'->'args'->> 0 = $2 AND
-    time > NOW() - INTERVAL '12 HOURS'
+    time > NOW() - INTERVAL '25 HOURS'
     ORDER by block DESC LIMIT $3;
   `,
       [queryChainId, queryBeaconId, MAX_TRANSACTION_COUNT_LIMIT]


### PR DESCRIPTION
This fixes an issue where beacons that were not updated within the last 12 hours returned an error. Airseeker forces an update every 24 hours which ensures that all graphs will show correclty.